### PR TITLE
fixed an arg for zero_shot_retrieval

### DIFF
--- a/src/train/main_editDistance.py
+++ b/src/train/main_editDistance.py
@@ -79,7 +79,7 @@ def main_editDistance(args, optuna_training=False):
         references_df, queries_df = dfs_list_inference[:2]
 
     models = []
-    if args.zero_shot_method:
+    if args.zero_shot_retrieval:
         for method in args.zero_shot_method.split(","):
             model = zero_shot_model(
                 embedding_layers_list,


### PR DESCRIPTION
This pull request fixes an issue where the workflow was not running correctly due to an incorrect argument used in an if statement.
The argument zero_shot_method was changed to zero_shot_retrieval in the corresponding 'if' statement in the main workflow file.